### PR TITLE
Reworked result tables for calculator to be boostrap tables.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -400,6 +400,10 @@ input[type=button] {
     padding: 1.25rem 0px;
 }
 
+.results-card-block table {
+    margin-bottom: 0px;
+}
+
 .header-subgroup {
     width: 100%;
     padding: 3px;

--- a/index.html
+++ b/index.html
@@ -1,6 +1,8 @@
 ﻿<!DOCTYPE html>
 <html>
-<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# object: http://ogp.me/ns/object# article: http://ogp.me/ns/article# profile: http://ogp.me/ns/profile#">
+
+<head
+    prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# object: http://ogp.me/ns/object# article: http://ogp.me/ns/article# profile: http://ogp.me/ns/profile#">
     <script>
         (function (i, s, o, g, r, a, m) {
             i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
@@ -20,8 +22,11 @@
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.6/angular.min.js"></script>
     <script src="js/KuroganeAPI.js"></script>
     <script src="js/calculator.js"></script>
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.4/css/bootstrap.min.css" integrity="sha384-2hfp1SzUoho7/TsGGGDaFdsuuDL0LX2hnUp6VkX3CUQ2K4K+xjboZdsXyp4oUHZj" crossorigin="anonymous">
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.4/js/bootstrap.min.js" integrity="sha384-VjEeINv9OSwtWFLAtmc4JCtEJXXBub00gtSnszmspDLCtC0I4z4nqz7rEFbIZLLU" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.4/css/bootstrap.min.css"
+        integrity="sha384-2hfp1SzUoho7/TsGGGDaFdsuuDL0LX2hnUp6VkX3CUQ2K4K+xjboZdsXyp4oUHZj" crossorigin="anonymous">
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.4/js/bootstrap.min.js"
+        integrity="sha384-VjEeINv9OSwtWFLAtmc4JCtEJXXBub00gtSnszmspDLCtC0I4z4nqz7rEFbIZLLU"
+        crossorigin="anonymous"></script>
     <link id="favicon" rel="shortcut icon" href="./img/icon.png" type="image/png" />
     <link id="mainStyle" rel="stylesheet" type="text/css" href="css/style.css" />
     <link rel="stylesheet" type="text/css" href="css/characters.css" />
@@ -33,24 +38,30 @@
     <meta name="twitter:site" content="@Ruben_dal" />
     <meta name="twitter:title" content="Smash Ultimate Calculator" />
     <meta name="twitter:description" content="Smash Ultimate knockback calculator" />
-    <meta name="twitter:image:src" content="https://raw.githubusercontent.com/rubendal/SSBU-Calculator/gh-pages/img/icon.png" />
+    <meta name="twitter:image:src"
+        content="https://raw.githubusercontent.com/rubendal/SSBU-Calculator/gh-pages/img/icon.png" />
     <meta property="og:title" content="Smash Ultimate Calculator" />
-    <meta property="og:image" content="https://raw.githubusercontent.com/rubendal/SSBU-Calculator/gh-pages/img/icon.png" />
+    <meta property="og:image"
+        content="https://raw.githubusercontent.com/rubendal/SSBU-Calculator/gh-pages/img/icon.png" />
     <meta property="og:description" content="Smash Ultimate knockback calculator" />
 </head>
+
 <body ng-app="calculator" ng-controller="calculator">
 
     <div id="header" class="header">
         <div id="header-cont">
             <img id="header-icon" class="header-image invert" src="./img/icon.png" />
             <div id="header-text">
-                <a class="hide-link" href="https://github.com/rubendal/SSBU-Calculator" target="_blank"><h3>Smash Ultimate Calculator</h3></a>
+                <a class="hide-link" href="https://github.com/rubendal/SSBU-Calculator" target="_blank">
+                    <h3>Smash Ultimate Calculator</h3>
+                </a>
                 <br />
                 <span class="description"></span>
                 <br />
                 <div class="header-links">
                     <select id="appSelect" class="header-select" ng-model="appLink">
-                        <option ng-selected="$first" ng:repeat="a in apps" ng-attr-value="{{a.link}}">{{a.title}}</option>
+                        <option ng-selected="$first" ng:repeat="a in apps" ng-attr-value="{{a.link}}">{{a.title}}
+                        </option>
                     </select>
                     <a class="header-link" href="{{appLink}}" title="Go">&rarr;</a>
                 </div>
@@ -58,20 +69,24 @@
             <div id="header-right">
                 <span id="links">
                     <span>
-                        <a href="https://rubendal.github.io/Sm4sh-Calculator/" target="_blank" class="hide-link" title="Smash 4 Calculator">
+                        <a href="https://rubendal.github.io/Sm4sh-Calculator/" target="_blank" class="hide-link"
+                            title="Smash 4 Calculator">
                             <img class="header-link-icon" src="./img/smash4-icon.png" />
                         </a>
-                        <a href="https://twitter.com/Ruben_dal" target="_blank" class="hide-link" title="Twitter @Ruben_dal">
+                        <a href="https://twitter.com/Ruben_dal" target="_blank" class="hide-link"
+                            title="Twitter @Ruben_dal">
                             <img class="header-link-icon" src="./img/t-icon.png" />
                         </a>
-                        <a href="https://github.com/rubendal/SSBU-Calculator/wiki" target="_blank" class="hide-link" title="Wiki">
+                        <a href="https://github.com/rubendal/SSBU-Calculator/wiki" target="_blank" class="hide-link"
+                            title="Wiki">
                             <img class="header-link-icon invert" src="./img/icon.png" />
                         </a>
                         <a href="https://ko-fi.com/rubendal" target="_blank" class="hide-link" title="Donate">
                             <img class="header-link-icon" src="./img/kofi.png" />
                         </a>
                         <a href="https://github.com/rubendal" target="_blank" class="hide-link" title="Github">
-                            <img id="github-profile" class="header-link-icon2" src="https://avatars.githubusercontent.com/u/10661132?v=3" />
+                            <img id="github-profile" class="header-link-icon2"
+                                src="https://avatars.githubusercontent.com/u/10661132?v=3" />
                         </a>
                     </span>
                 </span>
@@ -85,13 +100,13 @@
                     <a class="hide-link" target="_blank" href="https://github.com/rubendal/SSBU-Calculator#readme">Read this before using app</a>
                 </span>-->
             </div>
-            
+
         </div>
-        
+
     </div>
 
     <div name="calculator" id="calculator">
-        
+
         <div id="main">
 
             <!--  Characters -->
@@ -108,30 +123,38 @@
                             <div>Attacker</div>
                             <div class="char-select">
                                 <!--<img ng-src="{{attacker_icon}}" class="stock-icon" />-->
-                                <span class="character-image-cont"><img ng-src="{{attacker_image}}" class="character-image" ng-class="attacker_class" /></span>
+                                <span class="character-image-cont"><img ng-src="{{attacker_image}}"
+                                        class="character-image" ng-class="attacker_class" /></span>
                                 <div class="percent-div">
-                                    <input name="attacker_percent" type="number" class="percent-input" min="0" max="999" step="0.1" ng-model="attackerPercent" ng-style="attackerPercent_style" ng-change="updatePercent()" />
+                                    <input name="attacker_percent" type="number" class="percent-input" min="0" max="999"
+                                        step="0.1" ng-model="attackerPercent" ng-style="attackerPercent_style"
+                                        ng-change="updatePercent()" />
                                     <span ng-style="attackerPercent_style">%</span>
                                 </div>
                                 <div class="character-select-container" ng-class="attacker_class">
-                                    <select name="attackerSelect" class="character-select" ng-model="attackerValue" ng-change="updateAttacker()">
-                                        <option ng-selected="$first" ng:repeat="character in attacker_characters" ng-attr-value="{{character}}">{{character}}</option>
+                                    <select name="attackerSelect" class="character-select" ng-model="attackerValue"
+                                        ng-change="updateAttacker()">
+                                        <option ng-selected="$first" ng:repeat="character in attacker_characters"
+                                            ng-attr-value="{{character}}">{{character}}</option>
                                     </select>
                                 </div>
-                                
+
                             </div>
-                            
+
                             <div id="attacker-mod-sel" ng-style="attacker_mod">
                                 <br />
-                                <select name="attackerMod" class="mod-select" ng-model="attackerMod" ng-change="updateAttackerMod()">
-                                    <option ng-selected="$first" ng:repeat="mod in attackerModifiers" ng-attr-value="{{mod.name}}">{{mod.name}}</option>
+                                <select name="attackerMod" class="mod-select" ng-model="attackerMod"
+                                    ng-change="updateAttackerMod()">
+                                    <option ng-selected="$first" ng:repeat="mod in attackerModifiers"
+                                        ng-attr-value="{{mod.name}}">{{mod.name}}</option>
                                 </select>
                                 <br />
                             </div>
                             <div ng-style="is_lucario" class="auraParam">
                                 Stock difference
                                 <select ng-model="stock_dif" ng-change="update()">
-                                    <option ng:repeat="value in stock_values" ng-attr-value="{{value}}">{{value}}</option>
+                                    <option ng:repeat="value in stock_values" ng-attr-value="{{value}}">{{value}}
+                                    </option>
                                 </select>
                             </div>
                         </div>
@@ -139,27 +162,35 @@
                             <div>Target</div>
                             <div class="char-select">
                                 <!--<img ng-src="{{target_icon}}" class="stock-icon" />-->
-                                <span class="character-image-cont"><img ng-src="{{target_image}}" class="character-image" ng-class="target_class" /></span>
+                                <span class="character-image-cont"><img ng-src="{{target_image}}"
+                                        class="character-image" ng-class="target_class" /></span>
                                 <div class="percent-div">
-                                    <input name="target_percent" type="number" class="percent-input" min="0" max="999" step="0.1" ng-model="targetPercent" ng-style="targetPercent_style" ng-change="updatePercent()" />
+                                    <input name="target_percent" type="number" class="percent-input" min="0" max="999"
+                                        step="0.1" ng-model="targetPercent" ng-style="targetPercent_style"
+                                        ng-change="updatePercent()" />
                                     <span ng-style="targetPercent_style">%</span>
                                 </div>
                                 <div class="character-select-container" ng-class="target_class">
-                                    <select name="targetSelect" class="character-select" ng-model="targetValue" ng-change="updateTarget()">
-                                        <option ng-selected="$first" ng:repeat="character in characters" ng-attr-value="{{character}}">{{character}}</option>
+                                    <select name="targetSelect" class="character-select" ng-model="targetValue"
+                                        ng-change="updateTarget()">
+                                        <option ng-selected="$first" ng:repeat="character in characters"
+                                            ng-attr-value="{{character}}">{{character}}</option>
                                     </select>
                                 </div>
                             </div>
-                            
+
                             <div id="target-mod-sel" ng-style="target_mod">
                                 <br />
-                                <select name="targetMod" class="mod-select" ng-model="targetMod" ng-change="updateTargetMod()">
-                                    <option ng-selected="$first" ng:repeat="mod in targetModifiers" ng-attr-value="{{mod.name}}">{{mod.name}}</option>
+                                <select name="targetMod" class="mod-select" ng-model="targetMod"
+                                    ng-change="updateTargetMod()">
+                                    <option ng-selected="$first" ng:repeat="mod in targetModifiers"
+                                        ng-attr-value="{{mod.name}}">{{mod.name}}</option>
                                 </select>
                             </div>
                             <div ng-style="lumaclass" class="luma">
                                 Luma
-                                <input name="luma_target_percent" type="number" min="0" max="50" step="0.5" ng-model="lumaPercent" ng-change="update()" />
+                                <input name="luma_target_percent" type="number" min="0" max="50" step="0.5"
+                                    ng-model="lumaPercent" ng-change="update()" />
                                 %
                             </div>
                         </div>
@@ -188,11 +219,13 @@
                 </tr>-->
                         <tr>
                             <td>Damage dealt</td>
-                            <td>x <input name="attacker_damage_dealt" type="number" min="0" max="100" step="0.01" ng-model="attacker_damage_dealt" ng-change="updateAttr()" /></td>
+                            <td>x <input name="attacker_damage_dealt" type="number" min="0" max="100" step="0.01"
+                                    ng-model="attacker_damage_dealt" ng-change="updateAttr()" /></td>
                         </tr>
                         <tr>
                             <td>KB dealt</td>
-                            <td>x <input name="attacker_kb_dealt" type="number" min="0" max="100" step="0.01" ng-model="attacker_kb_dealt" ng-change="updateAttr()" /></td>
+                            <td>x <input name="attacker_kb_dealt" type="number" min="0" max="100" step="0.01"
+                                    ng-model="attacker_kb_dealt" ng-change="updateAttr()" /></td>
                         </tr>
                     </table>
 
@@ -204,35 +237,45 @@
     </tr>-->
                         <tr>
                             <td>Damage taken</td>
-                            <td>x <input name="target_damage_taken" type="number" min="0" max="100" step="0.01" ng-model="target_damage_taken" ng-change="updateAttr()" /></td>
+                            <td>x <input name="target_damage_taken" type="number" min="0" max="100" step="0.01"
+                                    ng-model="target_damage_taken" ng-change="updateAttr()" /></td>
                         </tr>
                         <tr>
                             <td>KB received</td>
-                            <td>x <input name="target_kb_received" type="number" min="0" max="100" step="0.01" ng-model="target_kb_received" ng-change="updateAttr()" /></td>
+                            <td>x <input name="target_kb_received" type="number" min="0" max="100" step="0.01"
+                                    ng-model="target_kb_received" ng-change="updateAttr()" /></td>
                         </tr>
                         <tr>
                             <td>Weight</td>
-                            <td>&nbsp;&nbsp;&nbsp;<input name="target_weight" type="number" min="0" max="999" step="1" ng-model="target_weight" ng-change="updateAttr()" /></td>
+                            <td>&nbsp;&nbsp;&nbsp;<input name="target_weight" type="number" min="0" max="999" step="1"
+                                    ng-model="target_weight" ng-change="updateAttr()" /></td>
                         </tr>
                         <tr>
                             <td>Gravity</td>
-                            <td>&nbsp;&nbsp;&nbsp;<input name="target_gravity" type="number" min="0" max="10" step="0.001" ng-model="target_gravity" ng-change="updateAttr()" /></td>
+                            <td>&nbsp;&nbsp;&nbsp;<input name="target_gravity" type="number" min="0" max="10"
+                                    step="0.001" ng-model="target_gravity" ng-change="updateAttr()" /></td>
                         </tr>
                         <tr>
                             <td>Fall speed</td>
-                            <td>&nbsp;&nbsp;&nbsp;<input name="target_fall_speed" type="number" min="0" max="10" step="0.001" ng-model="target_fall_speed" ng-change="updateAttr()" /></td>
+                            <td>&nbsp;&nbsp;&nbsp;<input name="target_fall_speed" type="number" min="0" max="10"
+                                    step="0.001" ng-model="target_fall_speed" ng-change="updateAttr()" /></td>
                         </tr>
                         <tr>
                             <td>DamageFlyTop Gravity</td>
-                            <td>&nbsp;&nbsp;&nbsp;<input name="target_damageflytop_gravity" type="number" min="0" max="10" step="0.001" ng-model="target_damageflytop_gravity" ng-change="updateAttr()" /></td>
+                            <td>&nbsp;&nbsp;&nbsp;<input name="target_damageflytop_gravity" type="number" min="0"
+                                    max="10" step="0.001" ng-model="target_damageflytop_gravity"
+                                    ng-change="updateAttr()" /></td>
                         </tr>
                         <tr>
                             <td>DamageFlyTop Fall speed</td>
-                            <td>&nbsp;&nbsp;&nbsp;<input name="target_damageflytop_fall_speed" type="number" min="0" max="10" step="0.001" ng-model="target_damageflytop_fall_speed" ng-change="updateAttr()" /></td>
+                            <td>&nbsp;&nbsp;&nbsp;<input name="target_damageflytop_fall_speed" type="number" min="0"
+                                    max="10" step="0.001" ng-model="target_damageflytop_fall_speed"
+                                    ng-change="updateAttr()" /></td>
                         </tr>
                         <tr>
                             <td>Traction</td>
-                            <td>&nbsp;&nbsp;&nbsp;<input name="target_traction" type="number" min="0" max="1" step="0.001" ng-model="target_traction" ng-change="updateAttr()" /></td>
+                            <td>&nbsp;&nbsp;&nbsp;<input name="target_traction" type="number" min="0" max="1"
+                                    step="0.001" ng-model="target_traction" ng-change="updateAttr()" /></td>
                         </tr>
                     </table>
                 </div>
@@ -251,53 +294,65 @@
                     <div class="pos-left">
                         Attack
                         <select id="moveset" ng-model="move" ng-change="updateAttack()" ng-style="moveset_style">
-                            <option ng-selected="$first" ng:repeat="move in moveset" ng-attr-value="{{move.id}}">{{move.name}}</option>
+                            <option ng-selected="$first" ng:repeat="move in moveset" ng-attr-value="{{move.id}}">
+                                {{move.name}}</option>
                         </select>
                         <span ng-hide="moveset_info == null">{{moveset_info}}</span>
                         <br />
-                        <a class="select-link" href="http://kuroganehammer.com/Ultimate/{{encodedAttackerValue}}" target="_blank">{{attackerName}} frame data</a>
+                        <a class="select-link" href="http://kuroganehammer.com/Ultimate/{{encodedAttackerValue}}"
+                            target="_blank">{{attackerName}} frame data</a>
                         <br />
                         <div ng-style="counterStyle">
                             Countered Damage
-                            <input name="countered_base_damage" type="number" min="0" max="999" step="0.1" ng-model="counteredDamage" ng-change="counterDamage()" />
+                            <input name="countered_base_damage" type="number" min="0" max="999" step="0.1"
+                                ng-model="counteredDamage" ng-change="counterDamage()" />
                             <span>{{"x" + counterMult}}</span>
                         </div>
                         <table>
                             <tr>
                                 <td>Damage</td>
-                                <td><input name="base_damage" type="number" min="0" max="999" step="0.1" ng-model="baseDamage" ng-change="updateAttackData()" /></td>
+                                <td><input name="base_damage" type="number" min="0" max="999" step="0.1"
+                                        ng-model="baseDamage" ng-change="updateAttackData()" /></td>
                             </tr>
                             <tr ng-style="is_smash_visibility">
                                 <td>{{charging_frames_type}}</td>
-                                <td><input name="charge" type="number" min="{{charge_min}}" max="{{charge_max}}" step="1" ng-model="smashCharge" ng-change="updateCharge()" /></td>
+                                <td><input name="charge" type="number" min="{{charge_min}}" max="{{charge_max}}"
+                                        step="1" ng-model="smashCharge" ng-change="updateCharge()" /></td>
                             </tr>
                             <tr>
                                 <td>Hitlag</td>
-                                <td><input name="hitlag_multiplier" type="number" min="0" max="6" step="0.05" ng-model="hitlag" ng-change="update()" /></td>
+                                <td><input name="hitlag_multiplier" type="number" min="0" max="6" step="0.05"
+                                        ng-model="hitlag" ng-change="update()" /></td>
                             </tr>
                             <tr>
                                 <td>Angle</td>
-                                <td><input name="angle" type="number" min="0" max="367" step="1" ng-model="angle" ng-change="updateAttackData()" /></td>
+                                <td><input name="angle" type="number" min="0" max="367" step="1" ng-model="angle"
+                                        ng-change="updateAttackData()" /></td>
                             </tr>
                             <tr>
                                 <td>BKB</td>
-                                <td><input name="bkb" type="number" min="0" max="999" step="1" ng-model="bkb" ng-change="updateAttackData()" /></td>
+                                <td><input name="bkb" type="number" min="0" max="999" step="1" ng-model="bkb"
+                                        ng-change="updateAttackData()" /></td>
                             </tr>
                             <tr>
                                 <td>FKB</td>
-                                <td><input name="wbkb" type="number" min="0" max="999" step="1" ng-model="wbkb" ng-change="updateAttackData()" /></td>
+                                <td><input name="wbkb" type="number" min="0" max="999" step="1" ng-model="wbkb"
+                                        ng-change="updateAttackData()" /></td>
                             </tr>
                             <tr>
                                 <td>KBG</td>
-                                <td><input name="kbg" type="number" min="0" max="999" step="1" ng-model="kbg" ng-change="updateAttackData()" /></td>
+                                <td><input name="kbg" type="number" min="0" max="999" step="1" ng-model="kbg"
+                                        ng-change="updateAttackData()" /></td>
                             </tr>
                             <tr>
                                 <td>Shield Damage</td>
-                                <td><input name="shield_damage" type="number" min="-50" max="50" step="1" ng-model="shieldDamage" ng-change="updateAttackData()" /></td>
+                                <td><input name="shield_damage" type="number" min="-50" max="50" step="1"
+                                        ng-model="shieldDamage" ng-change="updateAttackData()" /></td>
                             </tr>
                             <tr>
-                                <td>Shieldstun</td>
-                                <td><input name="shieldstun_mult" type="number" min="0" max="10" step="0.01" ng-model="shieldstunMult" ng-change="updateAttackData()" /></td>
+                                <td>Shield stun</td>
+                                <td><input name="shieldstun_mult" type="number" min="0" max="10" step="0.01"
+                                        ng-model="shieldstunMult" ng-change="updateAttackData()" /></td>
                             </tr>
                             <tr>
                                 <td>Effect</td>
@@ -309,7 +364,8 @@
                             </tr>
                             <tr>
                                 <td>Hit frame</td>
-                                <td><input name="hit_frame" type="number" min="0" max="1000" step="1" ng-model="hit_frame" ng-change="update()" /></td>
+                                <td><input name="hit_frame" type="number" min="0" max="1000" step="1"
+                                        ng-model="hit_frame" ng-change="update()" /></td>
                                 <td>
                                     <span>
                                         <button ng-style="prev_hf" ng-click="prev_hit_frame()">&lt;</button>
@@ -319,23 +375,29 @@
                             </tr>
                             <tr>
                                 <td>{{use_landing_lag == "no" ? "FAF" : "Landing frame"}}</td>
-                                <td><input name="faf" type="number" min="0" max="1000" step="1" ng-model="faf" ng-change="update()" /></td>
+                                <td><input name="faf" type="number" min="0" max="1000" step="1" ng-model="faf"
+                                        ng-change="update()" /></td>
                             </tr>
                         </table>
                         <span ng-style="is_aerial">
-                            <input type="radio" ng-model="use_landing_lag" value="no" ng-change="update_faf()" /> Use move FAF
+                            <input type="radio" ng-model="use_landing_lag" value="no" ng-change="update_faf()" /> Use
+                            move FAF
                             <br />
-                            <input type="radio" ng-model="use_landing_lag" value="yes" ng-change="update_faf()" /> Use move landing lag
-                            <input name="landing_lag" type="number" ng-model="landing_lag" min="1" max="100" step="1" ng-change="update_landing_lag()" />
+                            <input type="radio" ng-model="use_landing_lag" value="yes" ng-change="update_faf()" /> Use
+                            move landing lag
+                            <input name="landing_lag" type="number" ng-model="landing_lag" min="1" max="100" step="1"
+                                ng-change="update_landing_lag()" />
                             <br />
-                            <input type="radio" ng-model="use_landing_lag" value="autocancel" ng-change="update_faf()" /> Use move autocancel
+                            <input type="radio" ng-model="use_landing_lag" value="autocancel"
+                                ng-change="update_faf()" /> Use move autocancel
                         </span>
                         <div class="staleness">
                             Staleness Queue
                             <table>
                                 <tr>
                                     <td ng-repeat="n in stale track by $index" class="queue-td">
-                                        <input class="queue-cb" name="stale{{$index}}" data-value="{{$index+1}}" type="checkbox" ng-model="stale[$index]" ng-change="update()" />
+                                        <input class="queue-cb" name="stale{{$index}}" data-value="{{$index+1}}"
+                                            type="checkbox" ng-model="stale[$index]" ng-change="update()" />
                                     </td>
                                 </tr>
                             </table>
@@ -343,7 +405,8 @@
                             <table>
                                 <tr>
                                     <td ng-repeat="n in stale track by $index" class="queue-td">
-                                        <input class="queue-cb" name="shieldStale{{$index}}" data-value="{{$index+1}}" type="checkbox" ng-model="shieldStale[$index]" ng-change="update()" />
+                                        <input class="queue-cb" name="shieldStale{{$index}}" data-value="{{$index+1}}"
+                                            type="checkbox" ng-model="shieldStale[$index]" ng-change="update()" />
                                     </td>
                                 </tr>
                             </table>
@@ -353,7 +416,8 @@
                         </div>
                     </div>
                     <div class="pos-right attack-options">
-                        <input type="checkbox" ng-model="is_smash" ng-change="charging()" /> {{charge_special ? "Chargeable" : "Smash attack"}}
+                        <input type="checkbox" ng-model="is_smash" ng-change="charging()" />
+                        {{charge_special ? "Chargeable" : "Smash attack"}}
                         <br />
                         <span ng-style="is_smash_visibility">
                             <span ng-style="is_megaman">
@@ -361,7 +425,8 @@
                                 <br />
                             </span>
                             <span ng-style="is_bayonetta">
-                                <input type="checkbox" ng-model="witch_time_charge" ng-change="update()" /> Witch Time active
+                                <input type="checkbox" ng-model="witch_time_charge" ng-change="update()" /> Witch Time
+                                active
                                 <br />
                             </span>
                         </span>
@@ -377,11 +442,14 @@
                         <br />
                         <input type="checkbox" ng-model="windbox" ng-change="updateAttackData()" /> Windbox/Flinchless
                         <br />
-                        <input type="checkbox" name="ignoreStale" ng-model="ignoreStale" ng-change="update()" /> Ignores staleness/rage
+                        <input type="checkbox" name="ignoreStale" ng-model="ignoreStale" ng-change="update()" /> Ignores
+                        staleness/rage
                         <br />
-                        <input type="checkbox" name="set_weight" ng-model="set_weight" ng-change="update()" /> Set weight
+                        <input type="checkbox" name="set_weight" ng-model="set_weight" ng-change="update()" /> Set
+                        weight
                         <br />
-                        <input type="checkbox" name="isFinishingTouch" ng-model="isFinishingTouch" ng-change="update()" /> Finishing Touch
+                        <input type="checkbox" name="isFinishingTouch" ng-model="isFinishingTouch"
+                            ng-change="update()" /> Finishing Touch
                     </div>
                 </div>
             </div>
@@ -411,7 +479,8 @@
                                     <td>Input</td>
                                     <td>
                                         <select id="stick_inputs" ng-model="stickInput" ng-change="updateStickInput()">
-                                            <option ng-selected="$first" ng:repeat="i in stickInputs" ng-attr-value="{{i}}">{{i.name}}</option>
+                                            <option ng-selected="$first" ng:repeat="i in stickInputs"
+                                                ng-attr-value="{{i}}">{{i.name}}</option>
                                         </select>
                                     </td>
                                 </tr>
@@ -425,15 +494,18 @@
                                 <table>
                                     <tr>
                                         <td>X</td>
-                                        <td><input name="stickX" type="number" min="-127" max="127" step="1" ng-model="stick.X" ng-change="updateDIInput()" /></td>
+                                        <td><input name="stickX" type="number" min="-127" max="127" step="1"
+                                                ng-model="stick.X" ng-change="updateDIInput()" /></td>
                                     </tr>
                                     <tr>
                                         <td>Y</td>
-                                        <td><input name="stickY" type="number" min="-127" max="127" step="1" ng-model="stick.Y" ng-change="updateDIInput()" /></td>
+                                        <td><input name="stickY" type="number" min="-127" max="127" step="1"
+                                                ng-model="stick.Y" ng-change="updateDIInput()" /></td>
                                     </tr>
                                     <tr>
                                         <td>Angle</td>
-                                        <td><input name="stickAngle" type="number" min="0" max="359" step="1" ng-model="stickAngle" ng-change="updateDIAngle()" /></td>
+                                        <td><input name="stickAngle" type="number" min="0" max="359" step="1"
+                                                ng-model="stickAngle" ng-change="updateDIAngle()" /></td>
                                     </tr>
                                 </table>
                             </div>
@@ -441,7 +513,8 @@
                             <br />
                             <div style="clear:left;">
                                 Launch Rate:
-                                <input name="launch_rate" type="number" min="0.5" max="2" step="0.1" ng-model="launch_rate" ng-change="update()" />
+                                <input name="launch_rate" type="number" min="0.5" max="2" step="0.1"
+                                    ng-model="launch_rate" ng-change="update()" />
                             </div>
                         </div>
                     </div>
@@ -449,16 +522,18 @@
                         <div class="pos-right shield-select">
                             Shield
                             <br />
-                            <input type="radio" name="shieldMod" ng-model="shield" ng-attr-value="normal" ng-change="update()" /> Normal shield
+                            <input type="radio" name="shieldMod" ng-model="shield" ng-attr-value="normal"
+                                ng-change="update()" /> Normal shield
                             <br />
-                            <input type="radio" name="shieldMod" ng-model="shield" ng-attr-value="perfect" ng-change="update()" /> Perfect shield
+                            <input type="radio" name="shieldMod" ng-model="shield" ng-attr-value="perfect"
+                                ng-change="update()" /> Perfect shield
                             <br />
                             <br />
                         </div>
                         <br />
                         <div id="kb_modifiers" class="pos-right pos-mod">
                             KB modifiers
-                            <br/>
+                            <br />
                             <select id="target-status" ng-model="kb_modifier" ng-change="update()">
                                 <option value="none">None</option>
                                 <option value="crouch">Crouch cancel</option>
@@ -494,7 +569,8 @@
                 </div>
             </a>
             <div id="genlink" class="card-block collapse group">
-                Copy this URL <input id="shareurl" readonly type="text" ng-model="sharing_url" onclick="this.select();" />
+                Copy this URL <input id="shareurl" readonly type="text" ng-model="sharing_url"
+                    onclick="this.select();" />
             </div>
 
             <!-- Share end -->
@@ -516,7 +592,8 @@
                                 Hitstun constant
                             </td>
                             <td>
-                                <input name="param_hitstun" type="number" min="0" max="999" step="0.01" ng-model="params.hitstun" ng-change="updateParameters()" />
+                                <input name="param_hitstun" type="number" min="0" max="999" step="0.01"
+                                    ng-model="params.hitstun" ng-change="updateParameters()" />
                             </td>
                         </tr>
                         <tr>
@@ -524,7 +601,8 @@
                                 Tumble hitstun threshold
                             </td>
                             <td>
-                                <input name="param_tumble_threshold" type="number" min="0" max="999" step="1" ng-model="params.tumble_threshold" ng-change="updateParameters()" />
+                                <input name="param_tumble_threshold" type="number" min="0" max="999" step="1"
+                                    ng-model="params.tumble_threshold" ng-change="updateParameters()" />
                             </td>
                         </tr>
                     </table>
@@ -535,7 +613,8 @@
                                 DI
                             </td>
                             <td>
-                                <input name="param_di" type="number" min="0" max="999" step="0.01" ng-model="params.di" ng-change="updateParameters()" />
+                                <input name="param_di" type="number" min="0" max="999" step="0.01" ng-model="params.di"
+                                    ng-change="updateParameters()" />
                             </td>
                         </tr>
                     </table>
@@ -548,7 +627,8 @@
                                 Upwards multiplier
                             </td>
                             <td>
-                                <input name="param_max_lsi" type="number" min="0" max="999" step="0.01" ng-model="params.lsi_max" ng-change="updateParameters()" />
+                                <input name="param_max_lsi" type="number" min="0" max="999" step="0.01"
+                                    ng-model="params.lsi_max" ng-change="updateParameters()" />
                             </td>
                         </tr>
                         <tr>
@@ -556,7 +636,8 @@
                                 Downwards multiplier
                             </td>
                             <td>
-                                <input name="param_min_lsi" type="number" min="0" max="999" step="0.01" ng-model="params.lsi_min" ng-change="updateParameters()" />
+                                <input name="param_min_lsi" type="number" min="0" max="999" step="0.01"
+                                    ng-model="params.lsi_min" ng-change="updateParameters()" />
                             </td>
                         </tr>
                     </table>
@@ -569,7 +650,8 @@
                                 Multiplier
                             </td>
                             <td>
-                                <input name="param_launch_speed" type="number" min="0" max="999" step="0.001" ng-model="params.launch_speed" ng-change="updateParameters()" />
+                                <input name="param_launch_speed" type="number" min="0" max="999" step="0.001"
+                                    ng-model="params.launch_speed" ng-change="updateParameters()" />
                             </td>
                         </tr>
                         <tr>
@@ -577,7 +659,8 @@
                                 Decay
                             </td>
                             <td>
-                                <input name="param_decay" type="number" min="0" max="999" step="0.01" ng-model="params.decay" ng-change="updateParameters()" />
+                                <input name="param_decay" type="number" min="0" max="999" step="0.01"
+                                    ng-model="params.decay" ng-change="updateParameters()" />
                             </td>
                         </tr>
                     </table>
@@ -594,7 +677,8 @@
                                 Multiplier
                             </td>
                             <td>
-                                <input name="param_gravity_mult" type="number" min="0" max="999" step="0.01" ng-model="params.gravity.mult" ng-change="updateParameters()" />
+                                <input name="param_gravity_mult" type="number" min="0" max="999" step="0.01"
+                                    ng-model="params.gravity.mult" ng-change="updateParameters()" />
                             </td>
                         </tr>
                         <tr>
@@ -602,7 +686,8 @@
                                 Constant
                             </td>
                             <td>
-                                <input name="param_gravity_const" type="number" min="0" max="999" step="0.01" ng-model="params.gravity.constant" ng-change="updateParameters()" />
+                                <input name="param_gravity_const" type="number" min="0" max="999" step="0.01"
+                                    ng-model="params.gravity.constant" ng-change="updateParameters()" />
                             </td>
                         </tr>
                     </table>
@@ -615,7 +700,8 @@
                                 Multiplier
                             </td>
                             <td>
-                                <input name="param_shield_mult" type="number" min="0" max="999" step="0.01" ng-model="params.shield.mult" ng-change="updateParameters()" />
+                                <input name="param_shield_mult" type="number" min="0" max="999" step="0.01"
+                                    ng-model="params.shield.mult" ng-change="updateParameters()" />
                             </td>
                         </tr>
                         <tr>
@@ -623,7 +709,8 @@
                                 Constant
                             </td>
                             <td>
-                                <input name="param_shield_mult" type="number" min="0" max="999" step="0.01" ng-model="params.shield.constant" ng-change="updateParameters()" />
+                                <input name="param_shield_mult" type="number" min="0" max="999" step="0.01"
+                                    ng-model="params.shield.constant" ng-change="updateParameters()" />
                             </td>
                         </tr>
                         <tr>
@@ -631,7 +718,8 @@
                                 Projectile multiplier
                             </td>
                             <td>
-                                <input name="param_shield_mult" type="number" min="0" max="999" step="0.01" ng-model="params.shield.projectile" ng-change="updateParameters()" />
+                                <input name="param_shield_mult" type="number" min="0" max="999" step="0.01"
+                                    ng-model="params.shield.projectile" ng-change="updateParameters()" />
                             </td>
                         </tr>
                         <tr>
@@ -639,11 +727,12 @@
                                 Perfect Shield multiplier
                             </td>
                             <td>
-                                <input name="param_shield_mult" type="number" min="0" max="999" step="0.01" ng-model="params.shield.perfectShield" ng-change="updateParameters()" />
+                                <input name="param_shield_mult" type="number" min="0" max="999" step="0.01"
+                                    ng-model="params.shield.perfectShield" ng-change="updateParameters()" />
                             </td>
                         </tr>
                     </table>
-                    
+
 
                 </div>
                 <div class="pos-right">
@@ -655,7 +744,8 @@
                                 Multiplier
                             </td>
                             <td>
-                                <input name="param_hitlag_mult" type="number" min="0" max="999" step="0.01" ng-model="params.hitlag.mult" ng-change="updateParameters()" />
+                                <input name="param_hitlag_mult" type="number" min="0" max="999" step="0.01"
+                                    ng-model="params.hitlag.mult" ng-change="updateParameters()" />
                             </td>
                         </tr>
                         <tr>
@@ -663,7 +753,8 @@
                                 Constant
                             </td>
                             <td>
-                                <input name="param_hitlag_const" type="number" min="0" max="999" step="0.01" ng-model="params.hitlag.constant" ng-change="updateParameters()" />
+                                <input name="param_hitlag_const" type="number" min="0" max="999" step="0.01"
+                                    ng-model="params.hitlag.constant" ng-change="updateParameters()" />
                             </td>
                         </tr>
                     </table>
@@ -676,7 +767,8 @@
                                 Frames
                             </td>
                             <td>
-                                <input name="param_airdodge_cancel_frames" type="number" min="0" max="999" step="1" ng-model="params.hitstunCancel.frames.airdodge" ng-change="updateParameters()" />
+                                <input name="param_airdodge_cancel_frames" type="number" min="0" max="999" step="1"
+                                    ng-model="params.hitstunCancel.frames.airdodge" ng-change="updateParameters()" />
                             </td>
                         </tr>
                         <tr>
@@ -684,7 +776,9 @@
                                 Max launch speed
                             </td>
                             <td>
-                                <input name="param_airdodge_cancel_ls" type="number" min="0" max="999" step="0.01" ng-model="params.hitstunCancel.launchSpeed.airdodge" ng-change="updateParameters()" />
+                                <input name="param_airdodge_cancel_ls" type="number" min="0" max="999" step="0.01"
+                                    ng-model="params.hitstunCancel.launchSpeed.airdodge"
+                                    ng-change="updateParameters()" />
                             </td>
                         </tr>
                     </table>
@@ -697,7 +791,8 @@
                                 Frames
                             </td>
                             <td>
-                                <input name="param_aerial_cancel_frames" type="number" min="0" max="999" step="1" ng-model="params.hitstunCancel.frames.aerial" ng-change="updateParameters()" />
+                                <input name="param_aerial_cancel_frames" type="number" min="0" max="999" step="1"
+                                    ng-model="params.hitstunCancel.frames.aerial" ng-change="updateParameters()" />
                             </td>
                         </tr>
                         <tr>
@@ -705,7 +800,8 @@
                                 Max launch speed
                             </td>
                             <td>
-                                <input name="param_aerial_cancel_ls" type="number" min="0" max="999" step="0.01" ng-model="params.hitstunCancel.launchSpeed.aerial" ng-change="updateParameters()" />
+                                <input name="param_aerial_cancel_ls" type="number" min="0" max="999" step="0.01"
+                                    ng-model="params.hitstunCancel.launchSpeed.aerial" ng-change="updateParameters()" />
                             </td>
                         </tr>
                     </table>
@@ -718,7 +814,8 @@
                                 Multiplier
                             </td>
                             <td>
-                                <input name="param_paral_mult" type="number" min="0" max="999" step="0.01" ng-model="params.paralyzer.mult" ng-change="updateParameters()" />
+                                <input name="param_paral_mult" type="number" min="0" max="999" step="0.01"
+                                    ng-model="params.paralyzer.mult" ng-change="updateParameters()" />
                             </td>
                         </tr>
                         <tr>
@@ -726,7 +823,8 @@
                                 Constant
                             </td>
                             <td>
-                                <input name="param_paral_const" type="number" min="0" max="999" step="0.01" ng-model="params.paralyzer.constant" ng-change="updateParameters()" />
+                                <input name="param_paral_const" type="number" min="0" max="999" step="0.01"
+                                    ng-model="params.paralyzer.constant" ng-change="updateParameters()" />
                             </td>
                         </tr>
                     </table>
@@ -737,7 +835,8 @@
                                 Buried KB multiplier
                             </td>
                             <td>
-                                <input name="param_buried_kb_mult" type="number" min="0" max="999" step="0.01" ng-model="params.buried_kb_mult" ng-change="updateParameters()" />
+                                <input name="param_buried_kb_mult" type="number" min="0" max="999" step="0.01"
+                                    ng-model="params.buried_kb_mult" ng-change="updateParameters()" />
                             </td>
                         </tr>
                         <tr>
@@ -745,11 +844,12 @@
                                 Buried KB resistance threshold
                             </td>
                             <td>
-                                <input name="param_buried_kb_threshold" type="number" min="0" max="999" step="0.01" ng-model="params.buried_kb_threshold" ng-change="updateParameters()" />
+                                <input name="param_buried_kb_threshold" type="number" min="0" max="999" step="0.01"
+                                    ng-model="params.buried_kb_threshold" ng-change="updateParameters()" />
                             </td>
                         </tr>
                     </table>
-                     
+
                 </div>
 
 
@@ -780,9 +880,9 @@
                     </a>
                     <div id="damage-results" class="card-block collapse in group-res subgroup">
                         <!-- Damage data -->
-                        <table class="result-table">
+                        <table class="table table-striped table-sm">
                             <tbody>
-                                <tr ng-repeat="x in results.damage.list" ng-class-even="'value-even'">
+                                <tr ng-repeat="x in results.damage.list">
                                     <td class="attribute" title="{{x.title}}">{{ x.name }}</td>
                                     <td class="value" title="{{x.title}}" ng-style="{{x.style}}">{{x.value}}</td>
                                 </tr>
@@ -798,9 +898,9 @@
                     </a>
                     <div id="kb-results" class="card-block collapse in group-res subgroup">
                         <!-- KB data -->
-                        <table class="result-table">
+                        <table class="table table-striped table-sm">
                             <tbody>
-                                <tr ng-repeat="x in results.kb.list" ng-class-even="'value-even'">
+                                <tr ng-repeat="x in results.kb.list">
                                     <td class="attribute" title="{{x.title}}">{{ x.name }}</td>
                                     <td class="value" title="{{x.title}}" ng-style="{{x.style}}">{{x.value}}</td>
                                 </tr>
@@ -815,9 +915,9 @@
                     </a>
                     <div id="shield-results" class="card-block collapse in group-res subgroup">
                         <!-- Shield data -->
-                        <table class="result-table">
+                        <table class="table table-striped table-sm result-table">
                             <tbody>
-                                <tr ng-repeat="x in results.shield.list" ng-class-even="'value-even'">
+                                <tr ng-repeat="x in results.shield.list">
                                     <td class="attribute" title="{{x.title}}">{{ x.name }}</td>
                                     <td class="value" title="{{x.title}}" ng-style="{{x.style}}">{{x.value}}</td>
                                 </tr>
@@ -843,7 +943,8 @@
                     <div class="pos-left">
                         Stage:
                         <select name="stageSelect" ng-model="stageValue" ng-change="updateStage()">
-                            <option ng-selected="$first" ng:repeat="stage in stages" ng-attr-value="{{$index}}">{{stage.stage}}</option>
+                            <option ng-selected="$first" ng:repeat="stage in stages" ng-attr-value="{{$index}}">
+                                {{stage.stage}}</option>
                         </select>
                         <br />
                         Set position on spawn:
@@ -855,19 +956,24 @@
                         <table>
                             <tr>
                                 <td>X</td>
-                                <td><input name="position_x" type="number" min="-500" max="500" step="1" ng-model="position_x" ng-change="update()" /></td>
+                                <td><input name="position_x" type="number" min="-500" max="500" step="1"
+                                        ng-model="position_x" ng-change="update()" /></td>
                             </tr>
                             <tr>
                                 <td>Y</td>
-                                <td><input name="position_y" type="number" min="-500" max="500" step="1" ng-model="position_y" ng-change="update()" /></td>
+                                <td><input name="position_y" type="number" min="-500" max="500" step="1"
+                                        ng-model="position_y" ng-change="update()" /></td>
                             </tr>
                         </table>
                         <div id="graph_options">
-                            <input type="checkbox" name="inverseX" ng-model="inverseX" ng-change="updateDI()" /> Target hit from right side
+                            <input type="checkbox" name="inverseX" ng-model="inverseX" ng-change="updateDI()" /> Target
+                            hit from right side
                         </div>
                         <br />
-                        Display <input name="extra_frames" type="number" min="0" max="99" step="1" ng-model="extra_vis_frames" ng-change="update()" style="width:3em;" /> additional actionable frames
-                        
+                        Display <input name="extra_frames" type="number" min="0" max="99" step="1"
+                            ng-model="extra_vis_frames" ng-change="update()" style="width:3em;" /> additional actionable
+                        frames
+
                         <br />
                         <br />
                         <!--
@@ -888,8 +994,8 @@
                             </select>
                             <br />
                         </span>
-                        
-            <!--<input type="radio" name="mode" ng-model="game_mode" ng-attr-value="training" ng-change="update()" /> Training mode
+
+                        <!--<input type="radio" name="mode" ng-model="game_mode" ng-attr-value="training" ng-change="update()" /> Training mode
             <br />
             <input type="radio" name="mode" ng-model="game_mode" ng-attr-value="vs" ng-change="update()" /> Vs mode
             <br />-->


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11806849/56457570-1e2f7800-637d-11e9-9fb6-ed05aedd1e29.png)

Left is old - Right is new.
This also scales with displays and work in mobile view.

Renamed the `Shieldstun` parameter in Attack to `Shield stun` to get the naming between Attack and Result even.

Also did a VS Code format, that's why there are a lot of changes. Actual meaningful changes start at like 864 (results section)