### PR TITLE
Fix Hit Advantage for projectiles

### DIFF
--- a/js/calculator.js
+++ b/js/calculator.js
@@ -938,7 +938,7 @@ app.controller('calculator', function ($scope) {
         //kbList.push(new Result("Max Vertical Distance", +vsDistance.max_y.toFixed(6)));
 
 
-		kbList.push(new Result("Hit Advantage", HitAdvantage(hitstun, is_projectile ? hitframe + Hitlag(StaleDamage(damage, stale, shieldStale, ignoreStale), hitlag, electric, HitlagCrouch(crouch)) : hitframe, $scope.use_landing_lag == "yes" ? faf + landing_lag : $scope.use_landing_lag == "autocancel" ? faf + attacker.attributes.hard_landing_lag : faf, effect == "Paralyze" ? ParalysisTime(vskb.kb, damage, hitlag, HitlagCrouch(crouch)) : 0)));
+		kbList.push(new Result("Hit Advantage", HitAdvantage(hitstun, is_projectile ? hitframe + Hitlag(StaleDamage(damageWithout1v1, stale, shieldStale, ignoreStale), hitlag, electric, HitlagCrouch(crouch)) - 1 : hitframe, $scope.use_landing_lag == "yes" ? faf + landing_lag : $scope.use_landing_lag == "autocancel" ? faf + attacker.attributes.hard_landing_lag : faf, effect == "Paralyze" ? ParalysisTime(vskb.kb, damage, hitlag, HitlagCrouch(crouch)) : 0)));
 
         if (target.name == "Rosalina And Luma") {
             if (!wbkb) {


### PR DESCRIPTION
Two issues:
1. The hitlag was being calculated with the post-1v1 multiplier damage
2. It doesn't take into account the fact that X frames of projectile hitlag only means X-1 additional advantage frames.

As an example of (2), consider a move that hits on frame 10 and deals 5 frames of hitlag. If it's a direct attack, the victim starts hitstun on the attacker's frame 11. If it's a projectile, the victim is in hitlag on the attacker's frames 10-14 and starts hitstun on frame 15 - this is only 4 frames later.