### PR TITLE
Fix Sora nair/fair 2/3 landing lag

### DIFF
--- a/Data/ulthitboxes/82_sora.json
+++ b/Data/ulthitboxes/82_sora.json
@@ -4468,6 +4468,7 @@
       "faf": 33,
       "name": "Neutral Air 2",
       "value": "SoraNAir2",
+      "custom_landing_lag": 10,
       "hitboxes": [
         {
           "id": "0",
@@ -4927,6 +4928,7 @@
       "faf": 41,
       "name": "Neutral Air 3",
       "value": "SoraNAir3",
+      "custom_landing_lag": 11,
       "hitboxes": [
         {
           "id": "0",
@@ -5436,6 +5438,7 @@
       "faf": 33,
       "name": "Forward Air 2",
       "value": "SoraFAir2",
+      "custom_landing_lag": 13,
       "hitboxes": [
         {
           "id": "0",
@@ -5895,6 +5898,7 @@
       "faf": 41,
       "name": "Forward Air 3",
       "value": "SoraFAir3",
+      "custom_landing_lag": 14,
       "hitboxes": [
         {
           "id": "0",

--- a/js/ultHitboxes.js
+++ b/js/ultHitboxes.js
@@ -147,7 +147,7 @@
 				}
 			}
 		}
-        if (data.custom_landing_lag) {
+		if (data.custom_landing_lag) {
 			//Necessary for Sora as nair and fair have different landing lags depending on number of swings
 			move.LandingLag = data.custom_landing_lag;
 		}

--- a/js/ultHitboxes.js
+++ b/js/ultHitboxes.js
@@ -147,6 +147,7 @@
 				}
 			}
 		}
+
 		if (data.custom_landing_lag) {
 			//Necessary for Sora as nair and fair have different landing lags depending on number of swings
 			move.LandingLag = data.custom_landing_lag;

--- a/js/ultHitboxes.js
+++ b/js/ultHitboxes.js
@@ -147,8 +147,11 @@
 				}
 			}
 		}
-
-		if (params && (data.name.includes("Nair") || data.name.includes("Fair") || data.name.includes("Bair") || data.name.includes("Uair") || data.name.includes("Dair"))) {
+        if (data.custom_landing_lag) {
+			//Necessary for Sora as nair and fair have different landing lags depending on number of swings
+			move.LandingLag = data.custom_landing_lag;
+		}
+		else if (params && (data.name.includes("Nair") || data.name.includes("Fair") || data.name.includes("Bair") || data.name.includes("Uair") || data.name.includes("Dair"))) {
 			//Use landing lag values from character parameters
 
 			if (data.name.includes("Nair")) {


### PR DESCRIPTION

This was leading to misleading frame advantage on the calculator, as the landing lag for some of Sora's aerials was wrong.

Sora's aerial landing lag:
Nair 1: 9
Nair 2: 10
Nair 3: 11
Fair 1: 12
Fair 2: 13
Fair 3: 14

The params for each character include NairLandingLag/FairLandingLag each as a single number, which isn't sufficient for Sora. I thus added an optional custom_landing_lag param for a move, and set it for Nair 2/3 and Fair 2/3.